### PR TITLE
Feat: 로그인 관련 인증 인가 구현 완료 - 액세스토큰& 리프레시토큰 자동로그아웃

### DIFF
--- a/Frontend/chat_app/package-lock.json
+++ b/Frontend/chat_app/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-query": "^5.45.1",
         "@types/axios": "^0.14.0",
         "axios": "^1.7.2",
+        "js-cookie": "^3.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^9.1.2",
@@ -21,6 +22,7 @@
       },
       "devDependencies": {
         "@tanstack/eslint-plugin-query": "^5.43.1",
+        "@types/js-cookie": "^3.0.6",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@typescript-eslint/eslint-plugin": "^7.2.0",
@@ -1701,6 +1703,12 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "dev": true
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
@@ -3120,6 +3128,14 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -5266,6 +5282,12 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
+    "@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "dev": true
+    },
     "@types/prop-types": {
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
@@ -6260,6 +6282,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/Frontend/chat_app/package.json
+++ b/Frontend/chat_app/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "^5.45.1",
     "@types/axios": "^0.14.0",
     "axios": "^1.7.2",
+    "js-cookie": "^3.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^9.1.2",
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^5.43.1",
+    "@types/js-cookie": "^3.0.6",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@typescript-eslint/eslint-plugin": "^7.2.0",

--- a/Frontend/chat_app/src/App.tsx
+++ b/Frontend/chat_app/src/App.tsx
@@ -3,14 +3,23 @@ import GlobalStyle from '@styles/GlobalStyle';
 import ChatRoomPage from '@/pages/ChatRoomPage';
 import ChatRoomListPage from '@/pages/ChatRoomListPage';
 import LoginPage from '@/pages/LoginPage';
+import RootLayout from '@/pages/Root';
 
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <ChatRoomListPage />,
+    element: <RootLayout />,
+    //errorElement: <ErrorPage/>,
+    id: 'root',
+    children: [
+      { index: true, element: <ChatRoomListPage /> },
+      {
+        path: 'login',
+        element: <LoginPage />,
+      },
+      { path: 'chat/:roomId', element: <ChatRoomPage /> },
+    ],
   },
-  { path: '/chat/:roomId', element: <ChatRoomPage /> },
-  { path: '/login', element: <LoginPage /> },
 ]);
 
 function App() {

--- a/Frontend/chat_app/src/App.tsx
+++ b/Frontend/chat_app/src/App.tsx
@@ -4,6 +4,7 @@ import ChatRoomPage from '@/pages/ChatRoomPage';
 import ChatRoomListPage from '@/pages/ChatRoomListPage';
 import LoginPage from '@/pages/LoginPage';
 import RootLayout from '@/pages/Root';
+import { action as logoutAction } from '@/pages/Logout';
 
 const router = createBrowserRouter([
   {
@@ -18,6 +19,10 @@ const router = createBrowserRouter([
         element: <LoginPage />,
       },
       { path: 'chat/:roomId', element: <ChatRoomPage /> },
+      {
+        path: 'logout',
+        action: logoutAction,
+      },
     ],
   },
 ]);

--- a/Frontend/chat_app/src/apis/authentication.ts
+++ b/Frontend/chat_app/src/apis/authentication.ts
@@ -13,3 +13,15 @@ export const sendLoginRequest = async ({ email, password }: { email: string; pas
     console.log(`status::${status}- ${text}`);
   }
 };
+
+export const reissueAccessTokenRequest = async (refreshToken: string) => {
+  try {
+    const response = await axios.post(`${import.meta.env.VITE_SPRING_URL}/refresh-token`, {
+      refreshToken,
+    });
+    return response.data; // 응답 데이터 반환
+  } catch (error) {
+    console.error('Failed to refresh access token:', error);
+    throw error;
+  }
+};

--- a/Frontend/chat_app/src/apis/authentication.ts
+++ b/Frontend/chat_app/src/apis/authentication.ts
@@ -1,27 +1,10 @@
-import { User } from '@/types/types';
 import axios from 'axios';
-
-// export const authenticateUser = async ({ userEmail, password }: { userEmail: string; password: string }) => {
-//   const encodedData = btoa(`${userEmail}:${password}`);
-//   try {
-//     const response = await axios.get(`${import.meta.env.VITE_SPRING_URL}/user`, {
-//       headers: { Authorization: `Basic ${encodedData}` },
-//     });
-//     const jwtToken: string = response.headers['authorization'];
-//     const userData: User = response.data;
-//     return { userData, jwtToken };
-//   } catch (error: any) {
-//     const status = error.response.status;
-//     const text = error.response.statusText;
-//     console.log(`status::${status}- ${text}`);
-//   }
-// };
 
 export const sendLoginRequest = async ({ email, password }: { email: string; password: string }) => {
   try {
     const res = await axios.post(`${import.meta.env.VITE_SPRING_URL}/login`, {
       email,
-      password,
+      pwd: password,
     });
     return res.data;
   } catch (err: any) {

--- a/Frontend/chat_app/src/apis/authentication.ts
+++ b/Frontend/chat_app/src/apis/authentication.ts
@@ -1,18 +1,32 @@
 import { User } from '@/types/types';
 import axios from 'axios';
 
-export const authenticateUser = async ({ userEmail, password }: { userEmail: string; password: string }) => {
-  const encodedData = btoa(`${userEmail}:${password}`);
+// export const authenticateUser = async ({ userEmail, password }: { userEmail: string; password: string }) => {
+//   const encodedData = btoa(`${userEmail}:${password}`);
+//   try {
+//     const response = await axios.get(`${import.meta.env.VITE_SPRING_URL}/user`, {
+//       headers: { Authorization: `Basic ${encodedData}` },
+//     });
+//     const jwtToken: string = response.headers['authorization'];
+//     const userData: User = response.data;
+//     return { userData, jwtToken };
+//   } catch (error: any) {
+//     const status = error.response.status;
+//     const text = error.response.statusText;
+//     console.log(`status::${status}- ${text}`);
+//   }
+// };
+
+export const sendLoginRequest = async ({ email, password }: { email: string; password: string }) => {
   try {
-    const response = await axios.get(`${import.meta.env.VITE_SPRING_URL}/user`, {
-      headers: { Authorization: `Basic ${encodedData}` },
+    const res = await axios.post(`${import.meta.env.VITE_SPRING_URL}/login`, {
+      email,
+      password,
     });
-    const jwtToken: string = response.headers['authorization'];
-    const userData: User = response.data;
-    return { userData, jwtToken };
-  } catch (error: any) {
-    const status = error.response.status;
-    const text = error.response.statusText;
+    return res.data;
+  } catch (err: any) {
+    const status = err.response.status;
+    const text = err.response.statusText;
     console.log(`status::${status}- ${text}`);
   }
 };

--- a/Frontend/chat_app/src/apis/axiosInstance.ts
+++ b/Frontend/chat_app/src/apis/axiosInstance.ts
@@ -1,5 +1,8 @@
+import { reissueAccessTokenRequest } from '@/apis/authentication';
 import store from '@/redux/store';
+import { setToken } from '@/redux/userSlice';
 import axios from 'axios';
+import Cookies from 'js-cookie';
 
 const api = axios.create({
   baseURL: `${import.meta.env.VITE_SPRING_URL}`,
@@ -27,14 +30,33 @@ api.interceptors.response.use(
   (response) => {
     return response;
   },
-  (error) => {
+  async (error) => {
     // 요청이 실패했을 때 실행될 로직
+    const originalRequest = error.config;
     if (error.response) {
       // 요청이 전송되었고 서버가 2xx 외의 상태 코드로 응답한 경우
       switch (error.response.status) {
         case 401:
-          // 인증 오류 처리
-          console.error('Unauthorized access - possibly invalid token');
+          if (!originalRequest._retry) {
+            originalRequest._retry = true;
+          }
+          try {
+            const token = Cookies.get('refreshToken');
+            if (!token) throw new Error('no refreshToken!');
+            const { accessToken, refreshToken } = await reissueAccessTokenRequest(token);
+            store.dispatch(setToken(accessToken));
+            Cookies.set('refreshToken', refreshToken);
+            axios.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+            originalRequest.headers['Authorization'] = `Bearer ${accessToken}`;
+
+            return api(originalRequest);
+          } catch (refreshError) {
+            console.error('Token refresh failed:', refreshError);
+            Cookies.set('refreshToken', 'EXPIRED'); // 리프레시 토큰 삭제
+
+            return Promise.reject(refreshError);
+          }
+
           break;
         case 404:
           // 요청한 리소스를 찾을 수 없음

--- a/Frontend/chat_app/src/apis/axiosInstance.ts
+++ b/Frontend/chat_app/src/apis/axiosInstance.ts
@@ -14,7 +14,7 @@ api.interceptors.request.use(
     const { accessToken } = state.user;
 
     if (accessToken) {
-      config.headers['Authorization'] = `${accessToken}`;
+      config.headers['Authorization'] = `Bearer ${accessToken}`;
     }
     return config;
   },
@@ -28,7 +28,7 @@ api.interceptors.response.use(
     return response;
   },
   (error) => {
-     // 요청이 실패했을 때 실행될 로직
+    // 요청이 실패했을 때 실행될 로직
     if (error.response) {
       // 요청이 전송되었고 서버가 2xx 외의 상태 코드로 응답한 경우
       switch (error.response.status) {
@@ -53,5 +53,5 @@ api.interceptors.response.use(
     }
     //오류 처리 후 throw하여 호출한 곳에서 처리할 수 있게 함.
     return Promise.reject(error);
-  }
+  },
 );

--- a/Frontend/chat_app/src/apis/user.ts
+++ b/Frontend/chat_app/src/apis/user.ts
@@ -17,10 +17,10 @@ export const putProfileImg = async (url: string, file: File) => {
     if (!url) {
       throw new Error('Require presignedURl');
     }
-    console.log('file', file);
-    console.log('url', url);
     const response = await axios.put(url, file, {
-      headers: { 'Content-Type': file.type },
+      headers: {
+        'Content-Type': file.type,
+      },
     });
     console.log(response);
     return true;

--- a/Frontend/chat_app/src/apis/user.ts
+++ b/Frontend/chat_app/src/apis/user.ts
@@ -11,3 +11,22 @@ export const getPresignedURL = async (userId: number) => {
     console.log(`status::${status}- ${text}`);
   }
 };
+
+export const putProfileImg = async (url: string, file: File) => {
+  try {
+    if (!url) {
+      throw new Error('Require presignedURl');
+    }
+    console.log('file', file);
+    console.log('url', url);
+    const response = await axios.put(url, file, {
+      headers: { 'Content-Type': file.type },
+    });
+    console.log(response);
+    return true;
+  } catch (error: any) {
+    const status = error.response.status;
+    const text = error.response.statusText;
+    console.log(`status::${status}- ${text}`);
+  }
+};

--- a/Frontend/chat_app/src/apis/user.ts
+++ b/Frontend/chat_app/src/apis/user.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+export const getPresignedURL = async (userId: number) => {
+  if (userId === null) throw new Error('Require userId');
+  try {
+    const response = await axios.get(`${import.meta.env.VITE_PROFILE_LAMBDA}/presignedURL/${userId}`);
+    return response.data.url;
+  } catch (error: any) {
+    const status = error.response.status;
+    const text = error.response.statusText;
+    console.log(`status::${status}- ${text}`);
+  }
+};

--- a/Frontend/chat_app/src/components/ChatRoom/ChatsWrapper.tsx
+++ b/Frontend/chat_app/src/components/ChatRoom/ChatsWrapper.tsx
@@ -12,9 +12,11 @@ interface chatRoomProps {
 
 function ChatWrapper({ chatDatas, loadMoreRef, data }: chatRoomProps) {
   const user = useSelector((state: RootState) => state.user);
+  console.log('chatDatas', chatDatas);
   return (
     <Wrapper>
       <div ref={loadMoreRef} />
+      {/* 이전 채팅 */}
       {data.pages.map((page: { pastChats: any[] }) =>
         page.pastChats.map((chat, index) => {
           const hour = String(chat.createDate?.hour).padStart(2, '0');
@@ -28,6 +30,7 @@ function ChatWrapper({ chatDatas, loadMoreRef, data }: chatRoomProps) {
           );
         }),
       )}
+      {/* 실시간 채팅 */}
       {chatDatas.map((chat, index) => {
         const hour = String(chat.createDate?.hour).padStart(2, '0');
         const minute = String(chat.createDate.min).padStart(2, '0');

--- a/Frontend/chat_app/src/components/ChatRoomList/ProfileBox.tsx
+++ b/Frontend/chat_app/src/components/ChatRoomList/ProfileBox.tsx
@@ -1,5 +1,5 @@
 import { getPresignedURL, putProfileImg } from '@/apis/user';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import styled from 'styled-components';
 
 interface ProfileProps {
@@ -9,6 +9,7 @@ interface ProfileProps {
 }
 function ProfileBox({ imgUrl, userName, userId }: ProfileProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [fileUrl, setFileUrl] = useState<string>(imgUrl);
   const handleUpdateImg = async () => {
     if (fileInputRef.current) {
       fileInputRef.current.click();
@@ -17,6 +18,8 @@ function ProfileBox({ imgUrl, userName, userId }: ProfileProps) {
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e?.target.files?.[0];
     if (file) {
+      const newFileUrl = URL.createObjectURL(file);
+      setFileUrl(newFileUrl);
       const presignedURL = await getPresignedURL(userId!);
       const res = await putProfileImg(presignedURL, file);
       console.log(res);
@@ -25,7 +28,7 @@ function ProfileBox({ imgUrl, userName, userId }: ProfileProps) {
   return (
     <Container>
       <ProfileImgContainer onClick={handleUpdateImg}>
-        <ProfileImg src={imgUrl} />
+        <ProfileImg src={fileUrl} />
         <Overlay>
           <input
             ref={fileInputRef}

--- a/Frontend/chat_app/src/components/ChatRoomList/ProfileBox.tsx
+++ b/Frontend/chat_app/src/components/ChatRoomList/ProfileBox.tsx
@@ -1,4 +1,4 @@
-import { getPresignedURL } from '@/apis/user';
+import { getPresignedURL, putProfileImg } from '@/apis/user';
 import { useRef } from 'react';
 import styled from 'styled-components';
 
@@ -18,7 +18,8 @@ function ProfileBox({ imgUrl, userName, userId }: ProfileProps) {
     const file = e?.target.files?.[0];
     if (file) {
       const presignedURL = await getPresignedURL(userId!);
-      console.log('presignedURL', presignedURL);
+      const res = await putProfileImg(presignedURL, file);
+      console.log(res);
     }
   };
   return (

--- a/Frontend/chat_app/src/components/ChatRoomList/ProfileBox.tsx
+++ b/Frontend/chat_app/src/components/ChatRoomList/ProfileBox.tsx
@@ -1,4 +1,5 @@
 import { getPresignedURL } from '@/apis/user';
+import { useRef } from 'react';
 import styled from 'styled-components';
 
 interface ProfileProps {
@@ -7,15 +8,31 @@ interface ProfileProps {
   userId: number | null;
 }
 function ProfileBox({ imgUrl, userName, userId }: ProfileProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const handleUpdateImg = async () => {
-    const presignedURL = await getPresignedURL(userId!);
-    console.log('presignedURL', presignedURL);
+    if (fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  };
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e?.target.files?.[0];
+    if (file) {
+      const presignedURL = await getPresignedURL(userId!);
+      console.log('presignedURL', presignedURL);
+    }
   };
   return (
     <Container>
       <ProfileImgContainer onClick={handleUpdateImg}>
         <ProfileImg src={imgUrl} />
         <Overlay>
+          <input
+            ref={fileInputRef}
+            type="file"
+            style={{ display: 'none' }}
+            accept="image/*"
+            onChange={handleFileChange}
+          />
           <OverlayText>사진선택</OverlayText>
         </Overlay>
       </ProfileImgContainer>

--- a/Frontend/chat_app/src/components/ChatRoomList/ProfileBox.tsx
+++ b/Frontend/chat_app/src/components/ChatRoomList/ProfileBox.tsx
@@ -1,3 +1,4 @@
+import { getPresignedURL } from '@/apis/user';
 import styled from 'styled-components';
 
 interface ProfileProps {
@@ -6,9 +7,18 @@ interface ProfileProps {
   userId: number | null;
 }
 function ProfileBox({ imgUrl, userName, userId }: ProfileProps) {
+  const handleUpdateImg = async () => {
+    const presignedURL = await getPresignedURL(userId!);
+    console.log('presignedURL', presignedURL);
+  };
   return (
     <Container>
-      <ProfileImg src={imgUrl} />
+      <ProfileImgContainer onClick={handleUpdateImg}>
+        <ProfileImg src={imgUrl} />
+        <Overlay>
+          <OverlayText>사진선택</OverlayText>
+        </Overlay>
+      </ProfileImgContainer>
       <InfoContainer>
         <Name>{userName}</Name>
         <ID>{userId}</ID>
@@ -26,11 +36,43 @@ const Container = styled.div`
   gap: 12px;
   padding: 12px 18px;
 `;
-const ProfileImg = styled.img`
+const ProfileImgContainer = styled.div`
+  position: relative;
   width: 15%;
   border-radius: 50%;
-  padding: 2px 2px;
+  cursor: pointer;
+  overflow: hidden;
+
+  &:hover div {
+    opacity: 1;
+  }
 `;
+
+const ProfileImg = styled.img`
+  width: 100%;
+  border-radius: 50%;
+`;
+
+const Overlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+`;
+const OverlayText = styled.span`
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+`;
+
 const InfoContainer = styled.div`
   display: flex;
   flex-direction: column;

--- a/Frontend/chat_app/src/pages/ChatRoomListPage.tsx
+++ b/Frontend/chat_app/src/pages/ChatRoomListPage.tsx
@@ -37,7 +37,7 @@ const ChatRoomListPage = () => {
   useEffect(() => {
     //실시간으로 변하는 채팅방리스트 업데이트 웹소켓
     if (user.id && user.accessToken) {
-      dispatch(initializeWebSocket({ userId: user.id, accessToken: user.accessToken }));
+      dispatch(initializeWebSocket({ userId: user.id }));
     }
     return () => {
       // console.log('unmouited');

--- a/Frontend/chat_app/src/pages/ChatRoomPage.tsx
+++ b/Frontend/chat_app/src/pages/ChatRoomPage.tsx
@@ -41,7 +41,6 @@ function ChatRoomPage() {
     }
   }, [fetchNextPage, hasNextPage]);
   useEffect(() => {
-    console.log();
     if (client && isConnected && params.roomId) {
       const subscription = client.subscribe(`/sub/chat/${params.roomId}`, (message) => {
         const newChat = JSON.parse(message.body);

--- a/Frontend/chat_app/src/pages/LoginPage.tsx
+++ b/Frontend/chat_app/src/pages/LoginPage.tsx
@@ -18,7 +18,7 @@ function LoginPage() {
     if (response) {
       const { id, name, imgUrl, accessToken, refreshToken } = response;
       Cookies.set('refreshToken', refreshToken, { expires: 14 });
-      dispatch(setUser({ id, name, accessToken }));
+      dispatch(setUser({ id, name, accessToken, profileImg: imgUrl }));
       navigate('/', { replace: true });
       setUserEmail('');
       setPassword('');

--- a/Frontend/chat_app/src/pages/LoginPage.tsx
+++ b/Frontend/chat_app/src/pages/LoginPage.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import { Input, Main } from '@/styles/Common';
-import { authenticateUser } from '@/apis/authentication';
+import { sendLoginRequest } from '@/apis/authentication';
 import { useDispatch } from 'react-redux';
 import { AppDispatch } from '@/redux/store';
 import { setUser } from '@/redux/userSlice';
+import Cookies from 'js-cookie';
 import { useNavigate } from 'react-router-dom';
 
 function LoginPage() {
@@ -13,10 +14,11 @@ function LoginPage() {
   const [password, setPassword] = useState('');
   const dispatch = useDispatch<AppDispatch>();
   const handleLogin = async () => {
-    const response = await authenticateUser({ userEmail, password });
+    const response = await sendLoginRequest({ email: userEmail, password });
     if (response) {
-      const { userData, jwtToken } = response;
-      dispatch(setUser({ ...userData, accessToken: jwtToken }));
+      const { id, name, imgUrl, accessToken, refreshToken } = response;
+      Cookies.set('refreshToken', refreshToken, { expires: 14 });
+      dispatch(setUser({ id, name, accessToken }));
       navigate('/', { replace: true });
       setUserEmail('');
       setPassword('');
@@ -68,8 +70,6 @@ const Form = styled.div`
   width: 300px;
   gap: 10px;
 `;
-
-
 
 const Button = styled.button<{ secondary?: boolean }>`
   padding: 10px;

--- a/Frontend/chat_app/src/pages/Logout.tsx
+++ b/Frontend/chat_app/src/pages/Logout.tsx
@@ -1,0 +1,8 @@
+import store from '@/redux/store';
+import { initUser } from '@/redux/userSlice';
+import { redirect } from 'react-router-dom';
+
+export function action() {
+  store.dispatch(initUser());
+  return redirect('/login');
+}

--- a/Frontend/chat_app/src/pages/Root.tsx
+++ b/Frontend/chat_app/src/pages/Root.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { Outlet, useSubmit } from 'react-router-dom';
+import Cookies from 'js-cookie';
+
+function RootLayout() {
+  const token = Cookies.get('refreshToken');
+  const submit = useSubmit();
+
+  useEffect(() => {
+    if (token === 'EXPIRED') {
+      submit(null, { action: '/logout', method: 'post' });
+    }
+  }, [token, submit]);
+
+  return (
+    <>
+      {/* {navigation.state === 'loading' && <p>Loading...</p>} */}
+      <Outlet />
+    </>
+  );
+}
+
+export default RootLayout;

--- a/Frontend/chat_app/src/pages/Root.tsx
+++ b/Frontend/chat_app/src/pages/Root.tsx
@@ -7,6 +7,7 @@ function RootLayout() {
   const submit = useSubmit();
 
   useEffect(() => {
+    console.log('useEffect running');
     if (token === 'EXPIRED') {
       submit(null, { action: '/logout', method: 'post' });
     }

--- a/Frontend/chat_app/src/redux/userSlice.ts
+++ b/Frontend/chat_app/src/redux/userSlice.ts
@@ -6,6 +6,9 @@ interface userState {
   profileImg: string | null;
   accessToken: string | null;
 }
+interface tokenState {
+  accessToken: string;
+}
 const initialState: userState = {
   id: null,
   name: null,
@@ -17,13 +20,22 @@ export const userSlice = createSlice({
   name: 'user',
   initialState,
   reducers: {
+    initUser: (state) => {
+      state.id = null;
+      state.name = null;
+      state.profileImg = null;
+      state.accessToken = null;
+    },
     setUser: (state, action: PayloadAction<userState>) => {
       state.id = action.payload.id;
       state.name = action.payload.name;
       state.profileImg = action.payload.profileImg;
       state.accessToken = action.payload.accessToken;
     },
+    setToken: (state, action: PayloadAction<tokenState>) => {
+      state.accessToken = action.payload.accessToken;
+    },
   },
 });
-export const { setUser } = userSlice.actions;
+export const { setUser, setToken, initUser } = userSlice.actions;
 export default userSlice.reducer;

--- a/Frontend/chat_app/src/redux/userSlice.ts
+++ b/Frontend/chat_app/src/redux/userSlice.ts
@@ -3,11 +3,13 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 interface userState {
   id: number | null;
   name: string | null;
+  profileImg: string | null;
   accessToken: string | null;
 }
 const initialState: userState = {
   id: null,
   name: null,
+  profileImg: null,
   accessToken: null,
 };
 
@@ -18,6 +20,7 @@ export const userSlice = createSlice({
     setUser: (state, action: PayloadAction<userState>) => {
       state.id = action.payload.id;
       state.name = action.payload.name;
+      state.profileImg = action.payload.profileImg;
       state.accessToken = action.payload.accessToken;
     },
   },

--- a/Frontend/chat_app/src/redux/webSocketSlice.ts
+++ b/Frontend/chat_app/src/redux/webSocketSlice.ts
@@ -1,23 +1,21 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { Client, StompSubscription } from '@stomp/stompjs';
+import { Client } from '@stomp/stompjs';
 
 interface webSocketState {
   client: Client | null;
   isConnected: boolean;
-  subscriptions: Record<string, StompSubscription>;
 }
 const initialState: webSocketState = {
   client: null,
   isConnected: false,
-  subscriptions: {},
 };
 
 export const initializeWebSocket = createAsyncThunk(
   'webSocket/initializeWebSocket',
-  async ({ userId, accessToken }: { userId: number; accessToken: string }, { dispatch }) => {
+  async ({ userId }: { userId: number }, { dispatch }) => {
     const client = new Client({
       brokerURL: `${import.meta.env.VITE_BROKER_URL}/gs`,
-      connectHeaders: { Authorization: accessToken },
+      // connectHeaders: { Authorization: accessToken },
       debug: (str) => {
         console.log('bug', str);
       },
@@ -34,7 +32,7 @@ export const initializeWebSocket = createAsyncThunk(
     };
 
     client.activate();
-
+    console.log('client in inital', client);
     return client;
   },
 );
@@ -54,17 +52,6 @@ export const webSocketSlice = createSlice({
     setConnected: (state, action: PayloadAction<boolean>) => {
       state.isConnected = action.payload;
     },
-    addSubscription(state, action: PayloadAction<{ roomId: string; subscription: StompSubscription }>) {
-      const { roomId, subscription } = action.payload;
-      state.subscriptions[roomId] = subscription;
-    },
-    removeSubscription(state, action: PayloadAction<{ roomId: string }>) {
-      const { roomId } = action.payload;
-      if (state.subscriptions[roomId]) {
-        state.subscriptions[roomId].unsubscribe();
-        delete state.subscriptions[roomId];
-      }
-    },
   },
   extraReducers: (builder) => {
     builder
@@ -82,6 +69,6 @@ export const webSocketSlice = createSlice({
 });
 
 // Action creators are generated for each case reducer function
-export const { setClient, setConnected, addSubscription, removeSubscription } = webSocketSlice.actions;
+export const { setClient, setConnected } = webSocketSlice.actions;
 
 export default webSocketSlice.reducer;


### PR DESCRIPTION
## 구현 내용
- 로그인 시, 액세스토큰과  리프레시토큰을 발급받고 각각 리덕스와 쿠키에 저장
-  axios interceptors를 이용하여 리프레시토큰으로 액세스토큰을 재발급 요청하는 로직 구현
- 리프레시 토큰 또한 만료되었을 경우, 로그아웃 후 로그인 페이지로 리디렉션하도록 구현

## 구현 방법
자동로그아웃 구현 시 `react-router`의 `action`을 이용했다.
우선 로그아웃 기능은 추후 로그아웃 버튼으로도 로그아웃이 가능하게 둘 것이기 때문에 사용한 이유가 크다.

action은 router에서 데이터를 보낼 때 사용하는 것이다.
- useEffect로 리프레시 토큰에 변화가 있으면 EPIRED된 것인지 확인한다
- EXPIRED라면 /logout action을 실행한다
- logout Action은 사용자 정보를 초기화 하고 login페이지로 리다이렉트 시킨다.

axios interceptor 내에서 401에러로 재요청 후 리프레시토큰이 만료됐을 때 `window.location.href`를 사용하여 로그인페이지로 리디렉션 시키는 방식도 있다.
하지만 페이지가 전체 리로드 되어 라우터가 제공하는 빠른 전환 대신 페이지 전환이 느려진다는 점이다.
이 때문에 라우터를 이용해 리다이렉트하도록 작성했으나
토큰이 변화될 때마다 EXPIRED를 확인한다는 점에서 추후 개선할 필요가 있어보인다.